### PR TITLE
Update gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,21 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.3
-    - android-24
+    - build-tools-28.0.2
+    - android-27
     - android-22
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-22
+
+licenses:
+    - 'android-sdk-license-.+'
+    - 'android-sdk-preview-license-.+'
+    - 'google-gdk-license-.+'
+
+before_install:
+  - yes | sdkmanager "build-tools;28.0.2"
 
 before_script:
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -c 32M

--- a/ProgressButtonView/build.gradle
+++ b/ProgressButtonView/build.gradle
@@ -28,12 +28,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 12
         versionName "0.8.3"
     }
@@ -60,7 +60,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     testCompile 'junit:junit:4.12'
 }
 

--- a/ProgressButtonView/build.gradle
+++ b/ProgressButtonView/build.gradle
@@ -32,7 +32,7 @@ android {
     buildToolsVersion "28.0.2"
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 15
         targetSdkVersion 27
         versionCode 12
         versionName "0.8.3"

--- a/ProgressButtonView/src/main/java/es/voghdev/progressbuttonview/EfficientProgressButtonView.java
+++ b/ProgressButtonView/src/main/java/es/voghdev/progressbuttonview/EfficientProgressButtonView.java
@@ -18,7 +18,7 @@ package es.voghdev.progressbuttonview;
 import android.content.Context;
 import android.util.AttributeSet;
 
-class EfficientProgressButtonView extends ProgressButtonView {
+public class EfficientProgressButtonView extends ProgressButtonView {
     public EfficientProgressButtonView(Context context) {
         super(context);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
@@ -14,9 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         applicationId "es.voghdev.progressbuttonview.sample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
@@ -36,7 +36,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
     compile project(':ProgressButtonView')
     testCompile 'junit:junit:4.12'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -35,31 +35,31 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile project(':ProgressButtonView')
-    testCompile 'junit:junit:4.12'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation project(':ProgressButtonView')
+    testImplementation 'junit:junit:4.12'
 
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile('com.google.dexmaker:dexmaker-mockito:1.2') {
+    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
+    androidTestImplementation('com.google.dexmaker:dexmaker-mockito:1.2') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.android.support.test:rules:0.4.1'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.1') {
+    androidTestImplementation 'com.android.support.test:runner:0.4.1'
+    androidTestImplementation 'com.android.support.test:rules:0.4.1'
+    androidTestImplementation 'org.mockito:mockito-core:1.10.19'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.1') {
         exclude group: 'javax.inject', module: 'javax.inject'
         exclude group: 'com.squareup', module: 'javawriter'
     }
-    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.1') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:2.2.1') {
         exclude module: 'support-annotations'
         exclude module: 'recyclerview-v7'
         exclude module: 'support-v4'
     }
-    androidTestCompile('com.android.support.test.espresso:espresso-intents:2.2.1')
+    androidTestImplementation('com.android.support.test.espresso:espresso-intents:2.2.1')
 
-    debugCompile 'com.novoda:espresso-support-extras:0.0.3'
-    androidTestCompile 'com.novoda:espresso-support:0.0.3'
+    debugImplementation 'com.novoda:espresso-support-extras:0.0.3'
+    androidTestImplementation 'com.novoda:espresso-support:0.0.3'
 }
 
 configurations.all {


### PR DESCRIPTION
Updated gradle, build tools version, support library and used `implementation` instead of `compile`, which was deprecated in december 2018